### PR TITLE
Add option WithBaseCapacity to set base capacity of internal buffer

### DIFF
--- a/chanqueue.go
+++ b/chanqueue.go
@@ -111,7 +111,7 @@ func NewRing[T any](options ...Option[T]) *ChanQueue[T] {
 	}
 	if cq.capacity < 1 {
 		// Unbounded ring is the same as an unbounded queue.
-		return New(WithInput[T](cq.input))
+		return New(options...)
 	}
 	if cq.input == nil {
 		cq.input = make(chan T)

--- a/chanqueue.go
+++ b/chanqueue.go
@@ -10,11 +10,23 @@ import (
 type ChanQueue[T any] struct {
 	input, output chan T
 	length        chan int
+	baseCap       int
 	capacity      int
 	closeOnce     sync.Once
 }
 
 type Option[T any] func(*ChanQueue[T])
+
+// WithBaseCapacity sets the base capacity of the internal buffer so that at
+// least the specified number of items can always be stored without resizing
+// the buffer.
+func WithBaseCapacity[T any](n int) func(*ChanQueue[T]) {
+	return func(c *ChanQueue[T]) {
+		if n > 1 {
+			c.baseCap = n
+		}
+	}
+}
 
 // WithCapacity sets the limit on the number of unread items that ChanQueue
 // will hold. Unbuffered behavior is not supported (use a normal channel for
@@ -153,6 +165,12 @@ func (cq *ChanQueue[T]) Shutdown() {
 	}
 }
 
+func (cq *ChanQueue[T]) limitBaseCapToCapacity() {
+	if cq.capacity > 0 && cq.baseCap > cq.capacity {
+		cq.baseCap = cq.capacity
+	}
+}
+
 // bufferData is the goroutine that transfers data from the In() chan to the
 // buffer and from the buffer to the Out() chan.
 func (cq *ChanQueue[T]) bufferData() {
@@ -161,6 +179,9 @@ func (cq *ChanQueue[T]) bufferData() {
 	var next, zero T
 	inputChan := cq.input
 	input := inputChan
+
+	cq.limitBaseCapToCapacity()
+	buffer.SetBaseCap(cq.baseCap)
 
 	for input != nil || output != nil {
 		select {
@@ -211,6 +232,9 @@ func (cq *ChanQueue[T]) ringBufferData() {
 	var output chan T
 	var next, zero T
 	input := cq.input
+
+	cq.limitBaseCapToCapacity()
+	buffer.SetBaseCap(cq.baseCap)
 
 	for input != nil || output != nil {
 		select {

--- a/chanqueue_test.go
+++ b/chanqueue_test.go
@@ -292,12 +292,42 @@ func TestRing(t *testing.T) {
 	if string(out) != "fghij" {
 		t.Fatalf("expected \"fghij\" but got %q", out)
 	}
+}
 
-	cq = chanqueue.NewRing(chanqueue.WithCapacity[rune](0))
+func TestRingNoLimit(t *testing.T) {
+	inCh := make(chan rune)
+	outCh := make(chan rune)
+	// Test that options are passed through to New.
+	cq := chanqueue.NewRing(chanqueue.WithCapacity[rune](0),
+		chanqueue.WithInput[rune](inCh), chanqueue.WithOutput[rune](outCh))
 	if cq.Cap() != -1 {
 		t.Fatal("expected -1 capacity")
 	}
+	inCh <- 'A'
 	cq.Close()
+
+	var count int
+	to := time.After(time.Second)
+
+loop:
+	for {
+		select {
+		case char, open := <-outCh:
+			if !open {
+				break loop
+			}
+			count++
+			if char != 'A' {
+				t.Fatal("wrong character returned:", char)
+			}
+		case <-to:
+			t.Fatal("timed out waiting for out channel to close")
+		}
+	}
+
+	if count != 1 {
+		t.Fatal("wrong number of characters returned:", count)
+	}
 }
 
 func TestOneRing(t *testing.T) {

--- a/chanqueue_test.go
+++ b/chanqueue_test.go
@@ -131,7 +131,7 @@ func TestLimitedSpace(t *testing.T) {
 func TestBufferLimit(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	cq := chanqueue.New(chanqueue.WithCapacity[int](32))
+	cq := chanqueue.New(chanqueue.WithCapacity[int](32), chanqueue.WithBaseCapacity[int](1000))
 	defer cq.Shutdown()
 
 	for i := 0; i < cq.Cap(); i++ {


### PR DESCRIPTION
Fix missing options when creating unbounded ring using `NewRing`